### PR TITLE
Fix retrieval of organization key

### DIFF
--- a/Sdk/Tasks/DmappCreation.cs
+++ b/Sdk/Tasks/DmappCreation.cs
@@ -467,16 +467,33 @@ namespace Skyline.DataMiner.Sdk.Tasks
                 {
                     packageCreationData.CatalogDefaultDownloadToken = organizationKey;
                 }
+                else
+                {
+                    Logger.ReportDebug("No value found for CatalogDefaultDownloadKeyName.");
+                }
+            }
+            else
+            {
+                Logger.ReportDebug("No CatalogDefaultDownloadKeyName specified. Defaulting back to CatalogPublishKeyName.");
             }
 
-            // No organization key found, try to fallback to the publish key
-            if (organizationKey == null && !String.IsNullOrWhiteSpace(CatalogPublishKeyName))
+            // No organization key found, try to fall back to the publish key
+            if (String.IsNullOrWhiteSpace(organizationKey) && !String.IsNullOrWhiteSpace(CatalogPublishKeyName))
             {
                 organizationKey = configuration[CatalogPublishKeyName];
                 if (!String.IsNullOrWhiteSpace(organizationKey))
                 {
                     packageCreationData.CatalogDefaultDownloadToken = organizationKey;
                 }
+                else
+                {
+                    Logger.ReportDebug("No value found for CatalogPublishKeyName.");
+                }
+            }
+
+            if (String.IsNullOrWhiteSpace(organizationKey))
+            {
+                Logger.ReportDebug("No organization key could be found. If CatalogReferences are being used, an error will be thrown later in the code.");
             }
         }
 


### PR DESCRIPTION
Due to null check and not a String.IsNullOrWhitespace, the organization key was never properly filled in when using the complete workflow. Changed to String.IsNullOrWhitespace and added extra debuglogging as well.