### PR TITLE
[Suggestion] Add a clean step that removes the files generated in the DataMinerBuild folder

### DIFF
--- a/Sdk/Sdk/Sdk.targets
+++ b/Sdk/Sdk/Sdk.targets
@@ -26,7 +26,7 @@
             Debug="$(SkylineDataMinerSdkDebug)"
             />
     </Target>
-    
+
     <Target Name="CatalogInformation" AfterTargets="Build" Condition="'$(GenerateDataMinerPackage)' == 'true'">
         <CatalogInformation
             ProjectDirectory="$(MSBuildProjectDirectory)"
@@ -34,6 +34,10 @@
             PackageId="$(PackageId)"
             PackageVersion="$(Version)"
             />
+    </Target>
+
+    <Target Name="CleanDataMinerBuild" AfterTargets="Clean">
+        <RemoveDir Directories="$(OutDir)DataMinerBuild" />
     </Target>
 
     <Target Name="Publish" Condition="'$(GenerateDataMinerPackage)' == 'true'" DependsOnTargets="$(ConditionalBuildTarget)">


### PR DESCRIPTION
I noticed that when I ran the clean on my projects that the DataMinerBuild folder was always lingering. So as a suggestion I added a clean step that removes the DataMinerBuild when doing a clean. 