### PR TITLE
Only exclude NuGet.Frameworks for the unit test project

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
   CICD:
     needs: [dotnet-test]
-    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml@MasterWorkflow
+    uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml@main
     with:
       sonarcloud-project-name: SkylineCommunications_Skyline.DataMiner.Sdk
       nuget-push-source: https://api.nuget.org/v3/index.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="Runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" PrivateAssets="all" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
     <PackageVersion Include="NuGet.Frameworks" Version="7.3.0" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
-    <PackageVersion Include="Skyline.DataMiner.CICD.Assemblers.Automation" Version="6.0.1-alpha" />
-    <PackageVersion Include="Skyline.DataMiner.CICD.DMApp.Common" Version="6.0.1-alpha" />
+    <PackageVersion Include="Skyline.DataMiner.CICD.Assemblers.Automation" Version="6.0.0" />
+    <PackageVersion Include="Skyline.DataMiner.CICD.DMApp.Common" Version="6.0.0" />
     <PackageVersion Include="Skyline.DataMiner.Core.AppPackageCreator" Version="4.0.0" />
     <PackageVersion Include="Skyline.DataMiner.Core.ArtifactDownloader" Version="4.0.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="Nito.AsyncEx.Tasks" Version="5.1.2" />
     <PackageVersion Include="NuGet.Frameworks" Version="7.3.0" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
-    <PackageVersion Include="Skyline.DataMiner.CICD.Assemblers.Automation" Version="6.0.0" />
-    <PackageVersion Include="Skyline.DataMiner.CICD.DMApp.Common" Version="6.0.0" />
+    <PackageVersion Include="Skyline.DataMiner.CICD.Assemblers.Automation" Version="6.0.1-alpha" />
+    <PackageVersion Include="Skyline.DataMiner.CICD.DMApp.Common" Version="6.0.1-alpha" />
     <PackageVersion Include="Skyline.DataMiner.Core.AppPackageCreator" Version="4.0.0" />
     <PackageVersion Include="Skyline.DataMiner.Core.ArtifactDownloader" Version="4.0.0" />
   </ItemGroup>

--- a/SdkTests/SdkTests.csproj
+++ b/SdkTests/SdkTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="Runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request makes a minor adjustment to package references by moving the `NuGet.Frameworks` dependency from the shared `Directory.Build.props` to the `SdkTests/SdkTests.csproj` file. This change ensures that the dependency is only excluded in the test project where it is needed.

- Dependency management update:
  * Removed the `NuGet.Frameworks` package reference from the shared `Directory.Build.props` file, limiting its scope.
  * Added the `NuGet.Frameworks` package reference directly to the `SdkTests/SdkTests.csproj` file, ensuring it is only excluded to the test project.