### PR TITLE
Fix minimum DataMiner version handling in CatalogInformation

### DIFF
--- a/Sdk/Sdk/Sdk.targets
+++ b/Sdk/Sdk/Sdk.targets
@@ -34,6 +34,7 @@
             Output="$(OutDir)"
             PackageId="$(PackageId)"
             PackageVersion="$(Version)"
+            MinimumRequiredDmVersion="$(MinimumRequiredDmVersion)"
             />
     </Target>
 

--- a/Sdk/Tasks/CatalogInformation.cs
+++ b/Sdk/Tasks/CatalogInformation.cs
@@ -12,6 +12,7 @@ namespace Skyline.DataMiner.Sdk.Tasks
 
     using Microsoft.Build.Framework;
 
+    using Skyline.DataMiner.CICD.Common;
     using Skyline.DataMiner.CICD.FileSystem;
     using Skyline.DataMiner.Sdk.Helpers;
 
@@ -30,6 +31,8 @@ namespace Skyline.DataMiner.Sdk.Tasks
         public string PackageId { get; set; }
 
         public string PackageVersion { get; set; }
+
+        public string MinimumRequiredDmVersion { get; set; }
 
         #endregion Properties set from targets file
 
@@ -110,25 +113,40 @@ namespace Skyline.DataMiner.Sdk.Tasks
             var webpagesPublicDirectory = fs.Path.Combine(ProjectDirectory, "PackageContent", "CompanionFiles", "Skyline DataMiner", "Webpages", "Public");
             if (fs.Directory.Exists(webpagesPublicDirectory))
             {
-                // Get all files and folders directly under webpagesPublicDirectory
-                var entries = fs.Directory
-                    .EnumerateDirectories(webpagesPublicDirectory)
-                    .Select(path => fs.Path.Combine(pathToPublicDirectoryOnSystem, fs.Path.GetFileName(path)))
-                    .OrderBy(name => name)
-                    .ToList();
+                bool needsNotice = false;
 
-                entries.AddRange(fs.Directory
-                      .EnumerateFiles(webpagesPublicDirectory)
-                      .Select(path => fs.Path.Combine(pathToPublicDirectoryOnSystem, fs.Path.GetFileName(path)))
-                      .OrderBy(name => name)
-                      .ToList());
-
-                if (entries.Count > 0)
+                if (!String.IsNullOrEmpty(MinimumRequiredDmVersion))
                 {
-                    var readmeFilePath = fs.Path.Combine(catalogInformationFolder, "README.md");
-                    if (fs.File.Exists(readmeFilePath))
+                    DataMinerVersion version = DataMinerVersion.Parse(MinimumRequiredDmVersion);
+                    DataMinerVersion minVersion = new DataMinerVersion(10, 5, 10);
+                    needsNotice = version < minVersion;
+                }
+                else
+                {
+                    needsNotice = true;
+                }
+
+                if (needsNotice)
+                {
+                    // Get all files and folders directly under webpagesPublicDirectory
+                    var entries = fs.Directory
+                        .EnumerateDirectories(webpagesPublicDirectory)
+                        .Select(path => fs.Path.Combine(pathToPublicDirectoryOnSystem, fs.Path.GetFileName(path)))
+                        .OrderBy(name => name)
+                        .ToList();
+
+                    entries.AddRange(fs.Directory
+                          .EnumerateFiles(webpagesPublicDirectory)
+                          .Select(path => fs.Path.Combine(pathToPublicDirectoryOnSystem, fs.Path.GetFileName(path)))
+                          .OrderBy(name => name)
+                          .ToList());
+
+                    if (entries.Count > 0)
                     {
-                        var noticeLines = new List<string>
+                        var readmeFilePath = fs.Path.Combine(catalogInformationFolder, "README.md");
+                        if (fs.File.Exists(readmeFilePath))
+                        {
+                            var noticeLines = new List<string>
             {
                 "",
                 "",
@@ -139,11 +157,12 @@ namespace Skyline.DataMiner.Sdk.Tasks
                 ">",
             };
 
-                        noticeLines.AddRange(entries.Select(e => $">   - `{e}`"));
-                        noticeLines.Add(""); // final newline for clean formatting
+                            noticeLines.AddRange(entries.Select(e => $">   - `{e}`"));
+                            noticeLines.Add(""); // final newline for clean formatting
 
-                        var noticeText = string.Join(Environment.NewLine, noticeLines);
-                        fs.File.AppendAllText(readmeFilePath, noticeText);
+                            var noticeText = string.Join(Environment.NewLine, noticeLines);
+                            fs.File.AppendAllText(readmeFilePath, noticeText);
+                        }
                     }
                 }
             }

--- a/SdkTests/SdkTests.csproj
+++ b/SdkTests/SdkTests.csproj
@@ -6,15 +6,25 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>6b92a156-fb34-4699-9fbb-0585b2489709</UserSecretsId>
+    <!-- NuGet.Frameworks is intentionally copied to the output for net48, see below. -->
+    <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Build.Locator" />
-    <PackageReference Include="NuGet.Frameworks" ExcludeAssets="Runtime" PrivateAssets="all">
+    <!--
+      On .NET (net10.0) the dotnet SDK/MSBuild provides its own NuGet.Frameworks, so the runtime asset
+      must be excluded (see MSBuildLocator MSBL001) or MSBuild evaluation fails with an assembly mismatch.
+      On .NET Framework (net48) there is no MSBuild-provided copy, so the assembly must be copied to the
+      output. Otherwise an outdated NuGet.Frameworks is loaded and the (newer) NuGet.Packaging used by the
+      CICD assemblers throws MissingMethodException.
+    -->
+    <PackageReference Include="NuGet.Frameworks" Condition="'$(TargetFramework)' != 'net48'" ExcludeAssets="Runtime" PrivateAssets="all">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NuGet.Frameworks" Condition="'$(TargetFramework)' == 'net48'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SdkTests/Tasks/DmappCreationTests.cs
+++ b/SdkTests/Tasks/DmappCreationTests.cs
@@ -155,7 +155,7 @@
         }
 
         [TestMethod]
-        public void ExecuteCatalogInformation_WithNotice()
+        public void ExecuteCatalogInformation_WithNotice_HighMinimum()
         {
             string tempDirectory = FileSystem.Instance.Directory.CreateTemporaryDirectory();
             try
@@ -169,6 +169,137 @@
                     Output = tempDirectory,
                     PackageId = "My Package",
                     PackageVersion = "1.0.0",
+                    MinimumRequiredDmVersion = "10.7.0.0-18452",
+                    BuildEngine = buildEngine.Object
+                };
+
+                string expectedDestinationFilePath = FileSystem.Instance.Path.Combine(
+                    tempDirectory,
+                    BuildOutputHandler.BuildDirectoryName,
+                    $"{info.PackageId}.{info.PackageVersion}.CatalogInformation.zip");
+
+                // LOAD original README.md
+                string expectedReadmePath = FileSystem.Instance.Path.Combine(projectDir, "CatalogInformation", "README.md");
+                FileSystem.Instance.File.Exists(expectedReadmePath).Should().BeTrue("expected README.md must exist");
+                string expectedReadmeContent = FileSystem.Instance.File.ReadAllText(expectedReadmePath);
+
+                // Act
+                bool result = info.Execute();
+                errors.Should().BeEmpty();
+                result.Should().BeTrue();
+                FileSystem.Instance.File.Exists(expectedDestinationFilePath).Should().BeTrue();
+
+                // UNZIP to a temporary folder
+                string unzipDir = FileSystem.Instance.Path.Combine(tempDirectory, "unzipped");
+                ZipFile.ExtractToDirectory(expectedDestinationFilePath, unzipDir);
+
+                // FIND README.md inside the unzipped content
+                string[] readmeFiles = Directory.GetFiles(unzipDir, "README.md", SearchOption.AllDirectories);
+                readmeFiles.Length.Should().Be(1, "there should be exactly one README.md in the zipped output");
+                string actualReadmeContent = File.ReadAllText(readmeFiles[0]);
+                string expectedOriginalReadmeContent = FileSystem.Instance.File.ReadAllText(expectedReadmePath);
+
+                // Normalize line endings to \n and trim
+                string Normalize(string input) =>
+                    input.Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd();
+
+                string expectedWithNotice = expectedOriginalReadmeContent;
+
+
+                Normalize(actualReadmeContent)
+                    .Should().Be(Normalize(expectedWithNotice), "README.md content in zip should match source with a notice appended to it.");
+            }
+            finally
+            {
+                FileSystem.Instance.Directory.DeleteDirectory(tempDirectory);
+            }
+        }
+
+        [TestMethod]
+        public void ExecuteCatalogInformation_WithNotice_NoMinimum()
+        {
+            string tempDirectory = FileSystem.Instance.Directory.CreateTemporaryDirectory();
+            try
+            {
+                // Arrange
+                string projectDir = FileSystem.Instance.Path.Combine(TestHelper.GetTestFilesDirectory(), "Package 7", "My Package");
+
+                CatalogInformation info = new CatalogInformation()
+                {
+                    ProjectDirectory = projectDir,
+                    Output = tempDirectory,
+                    PackageId = "My Package",
+                    PackageVersion = "1.0.0",
+                    BuildEngine = buildEngine.Object
+                };
+
+                string expectedDestinationFilePath = FileSystem.Instance.Path.Combine(
+                    tempDirectory,
+                    BuildOutputHandler.BuildDirectoryName,
+                    $"{info.PackageId}.{info.PackageVersion}.CatalogInformation.zip");
+
+                // LOAD original README.md
+                string expectedReadmePath = FileSystem.Instance.Path.Combine(projectDir, "CatalogInformation", "README.md");
+                FileSystem.Instance.File.Exists(expectedReadmePath).Should().BeTrue("expected README.md must exist");
+                string expectedReadmeContent = FileSystem.Instance.File.ReadAllText(expectedReadmePath);
+
+                // Act
+                bool result = info.Execute();
+                errors.Should().BeEmpty();
+                result.Should().BeTrue();
+                FileSystem.Instance.File.Exists(expectedDestinationFilePath).Should().BeTrue();
+
+                // UNZIP to a temporary folder
+                string unzipDir = FileSystem.Instance.Path.Combine(tempDirectory, "unzipped");
+                ZipFile.ExtractToDirectory(expectedDestinationFilePath, unzipDir);
+
+                // FIND README.md inside the unzipped content
+                string[] readmeFiles = Directory.GetFiles(unzipDir, "README.md", SearchOption.AllDirectories);
+                readmeFiles.Length.Should().Be(1, "there should be exactly one README.md in the zipped output");
+                string actualReadmeContent = File.ReadAllText(readmeFiles[0]);
+                string expectedOriginalReadmeContent = FileSystem.Instance.File.ReadAllText(expectedReadmePath);
+
+                // Normalize line endings to \n and trim
+                string Normalize(string input) =>
+                    input.Replace("\r\n", "\n").Replace("\r", "\n").TrimEnd();
+
+                string expectedWithNotice = expectedOriginalReadmeContent +
+                    "\n\n" +
+                    "> [!IMPORTANT]\n" +
+                    ">\n" +
+                    "> - For DataMiner versions prior to 10.5.10, this package includes files located in `C:\\Skyline DataMiner\\Webpages\\Public` that are **not automatically deployed** to all Agents in a DataMiner System.\n" +
+                    "> - To ensure proper functionality across the entire cluster, manually copy the following files and folders to the corresponding location on each Agent after installation:\n" +
+                    ">\n" +
+                    ">   - `C:\\Skyline DataMiner\\Webpages\\Public\\MyDirectory`\n" +
+                    ">   - `C:\\Skyline DataMiner\\Webpages\\Public\\MyFile1.txt`\n" +
+                    ">   - `C:\\Skyline DataMiner\\Webpages\\Public\\XMLFile1.xml`";
+
+
+                Normalize(actualReadmeContent)
+                    .Should().Be(Normalize(expectedWithNotice), "README.md content in zip should match source with a notice appended to it.");
+            }
+            finally
+            {
+                FileSystem.Instance.Directory.DeleteDirectory(tempDirectory);
+            }
+        }
+
+        [TestMethod]
+        public void ExecuteCatalogInformation_WithNotice_LowMinimum()
+        {
+            string tempDirectory = FileSystem.Instance.Directory.CreateTemporaryDirectory();
+            try
+            {
+                // Arrange
+                string projectDir = FileSystem.Instance.Path.Combine(TestHelper.GetTestFilesDirectory(), "Package 7", "My Package");
+
+                CatalogInformation info = new CatalogInformation()
+                {
+                    ProjectDirectory = projectDir,
+                    Output = tempDirectory,
+                    PackageId = "My Package",
+                    PackageVersion = "1.0.0",
+                    MinimumRequiredDmVersion = "10.3.0.0-12752",
                     BuildEngine = buildEngine.Object
                 };
 


### PR DESCRIPTION
Fixes #129

Adds minimum DataMiner version handling to CatalogInformation so the Webpages/Public deployment notice is only added when required. Includes coverage for high, low, and unspecified minimum versions, wires the value through the SDK targets, and keeps the NuGet.Frameworks runtime fix required by the test matrix.